### PR TITLE
update testnet spec to be compatible with london hardfok

### DIFF
--- a/liberty-testnet-spec.json
+++ b/liberty-testnet-spec.json
@@ -43,7 +43,6 @@
     "eip1884Transition": 0,
     "eip2028Transition": 0,
     "eip2315Transition": 0,
-    "eip2315Transition": 0,
     "eip2929Transition": 0,
     "eip2930Transition": 0,
     "eip1559Transition": "0x1",

--- a/liberty-testnet-spec.json
+++ b/liberty-testnet-spec.json
@@ -1,5 +1,5 @@
 {
-  "name": "LibertyTestnetPoA",
+  "name": "liberty-testnet-poa",
   "engine": {
     "authorityRound": {
       "params": {
@@ -42,7 +42,17 @@
     "eip1344Transition": 0,
     "eip1884Transition": 0,
     "eip2028Transition": 0,
-    "eip2315Transition": 0
+    "eip2315Transition": 0,
+    "eip2315Transition": 0,
+    "eip2929Transition": 0,
+    "eip2930Transition": 0,
+    "eip1559Transition": "0x1",
+    "eip3198Transition": 0,
+    "eip3529Transition": 0,
+    "eip3541Transition": 0,
+    "eip1559BaseFeeMaxChangeDenominator": "0x8",
+    "eip1559ElasticityMultiplier": "0x2",
+    "eip1559BaseFeeInitialValue": "0x0"
   },
   "genesis": {
     "seal": {


### PR DESCRIPTION
### Problem
We need to update the testnet spec to be compatible with the london hardfork

### Solution
Update spec file with the necesssary EIP transitions